### PR TITLE
remove the usage of --ok flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SpectralOps - Automated Code Security Change Log
 
+## [1.0.18]
+
+- Remove the usage of --ok flag
+
 ## [1.0.14]
 
 - Support spectral yaml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "spectral-vscode-extension",
 	"displayName": "SpectralOps - A Check Point Solution",
 	"description": "Monitor your code for exposed API keys, tokens, credentials, and high-risk security misconfigurations",
-	"version": "1.0.14",
+	"version": "1.0.18",
 	"publisher": "SpectralOps",
 	"icon": "media/spectral.png",
 	"homepage": "https://spectralops.io/",

--- a/src/services/spectral-agent-service.ts
+++ b/src/services/spectral-agent-service.ts
@@ -51,7 +51,6 @@ export class SpectralAgentService {
         '--include-tags',
         'base,iac',
         '--nosend',
-        '--ok',
         '--internal-output',
         outputFileName,
       ]
@@ -78,23 +77,19 @@ export class SpectralAgentService {
       child.on('error', async (err) => {
         return reject(err)
       })
-      child.on('close', async (code) => {
+      child.on('close', async () => {
         if (!isEmpty(stderrChunks)) {
           const agentError = stderrChunks.join('')
           return reject(agentError)
         }
-        if (code === 0) {
-          try {
-            const filePath = path.join(scanPath, outputFileName)
-            const result = readFileSync(filePath, { encoding: 'utf8' })
-            unlinkSync(filePath)
-            const jsonOutput = JSON.parse(result)
-            return resolve(jsonOutput)
-          } catch (err) {
-            return reject(err)
-          }
-        } else {
-          return reject()
+        try {
+          const filePath = path.join(scanPath, outputFileName)
+          const result = readFileSync(filePath, { encoding: 'utf8' })
+          unlinkSync(filePath)
+          const jsonOutput = JSON.parse(result)
+          return resolve(jsonOutput)
+        } catch (err) {
+          return reject(err)
         }
       })
     })


### PR DESCRIPTION
## Description
This PR removes the usage of the --ok flag

## Motivation and Context
To support the hardening feature, spectral should not run with --ok by default.

## How Has This Been Tested?
- run spectral on a git repo -> issues are displayed in the secrets and iac tabs
- run spectral without an output file -> spectral fail and display the error in the output window

# Checklist
- [x] Tests
- [ ] Documentation
- [ ] Linting