### PR TITLE
add extension configuration for engines and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SpectralOps - Automated Code Security Change Log
 
+## [1.1.0]
+
+- Support user configuration for 'engines' and 'includesTags' flags
+
 ## [1.0.14]
 
 - Support spectral yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [1.1.0]
 
 - Support user configuration for 'engines' and 'includesTags' flags
+- Support OSS scanning
+
+## [1.0.18]
+
 - Remove the usage of --ok flag
 - Reset issues before scanning workspace folders
 - fix action button bug

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "spectral-vscode-extension",
 	"displayName": "SpectralOps - A Check Point Solution",
 	"description": "Monitor your code for exposed API keys, tokens, credentials, and high-risk security misconfigurations",
-	"version": "1.0.18",
+	"version": "1.1.0",
 	"publisher": "SpectralOps",
 	"icon": "media/spectral.png",
 	"homepage": "https://spectralops.io/",

--- a/package.json
+++ b/package.json
@@ -150,19 +150,19 @@
 					"spectral.scan.engines.useSecretsEngine": {
 							"type": "boolean",
 							"default": false,
-							"description": "Use Secrets and misconfigurations engine kind (Supported with Spectral version higher then 1.10.48)",
+							"description": "Secrets and misconfigurations engine (Supported from Spectral version 1.10.48 and above)",
 							"scope": "resource"
 					},
 					"spectral.scan.engines.useIacEngine": {
 							"type": "boolean",
 							"default": false,
-							"description": "Use infrastructure as code engine kind (Supported with Spectral version higher then 1.10.48, for IaC scan with lower version add 'iac' as includeTags)",
+							"description": "Use infrastructure as code engine kind (Supported from Spectral version 1.10.48 and above, for IaC scan with lower version add 'iac' as includeTags)",
 							"scope": "resource"
 					},
 					"spectral.scan.engines.useOssEngine": {
 						"type": "boolean",
 						"default": false,
-						"description": "Use open source engine kind (Supported with Spectral version higher then 1.10.48)",
+						"description": "Use open source engine kind (Supported from Spectral version 1.10.48 and above)",
 						"scope": "resource"
 				},
 					"spectral.scan.includeTags": {

--- a/package.json
+++ b/package.json
@@ -152,19 +152,19 @@
 					"spectral.scan.engines.useSecretsEngine": {
 							"type": "boolean",
 							"default": true,
-							"description": "Secrets and misconfigurations engine (Supported from Spectral version 1.10.48 and above)",
+							"description": "Scan for secrets",
 							"scope": "resource"
 					},
 					"spectral.scan.engines.useIacEngine": {
 							"type": "boolean",
 							"default": false,
-							"description": "Infrastructure as code engine (Supported from Spectral version 1.10.48 and above, for IaC scan with lower version add 'iac' as includeTags)",
+							"description": "Scan for infrastructure as code",
 							"scope": "resource"
 					},
 					"spectral.scan.engines.useOssEngine": {
 						"type": "boolean",
 						"default": false,
-						"description": "Open source engine (Supported from Spectral version 1.10.48 and above)",
+						"description": "Scan open source packages",
 						"scope": "resource"
 				},
 					"spectral.scan.includeTags": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
 					"id": "spectral.views.iac",
 					"name": "IaC",
 					"when": "spectral:scanState == 'success' || spectral:scanState == 'inProgress' && !spectral:preScan"
+				},
+				{
+					"id": "spectral.views.oss",
+					"name": "Open Source",
+					"when": "spectral:scanState == 'success' || spectral:scanState == 'inProgress' && !spectral:preScan"
 				}
 			]
 		},
@@ -154,6 +159,12 @@
 							"description": "Use infrastructure as code engine kind (Supported with Spectral version higher then 1.10.48, for IaC scan with lower version add 'iac' as includeTags)",
 							"scope": "resource"
 					},
+					"spectral.scan.engines.useOssEngine": {
+						"type": "boolean",
+						"default": false,
+						"description": "Use open source engine kind (Supported with Spectral version higher then 1.10.48)",
+						"scope": "resource"
+				},
 					"spectral.scan.includeTags": {
 							"type": "array",
 							"items": {

--- a/package.json
+++ b/package.json
@@ -156,13 +156,13 @@
 					"spectral.scan.engines.useIacEngine": {
 							"type": "boolean",
 							"default": false,
-							"description": "Use infrastructure as code engine kind (Supported from Spectral version 1.10.48 and above, for IaC scan with lower version add 'iac' as includeTags)",
+							"description": "Infrastructure as code engine (Supported from Spectral version 1.10.48 and above, for IaC scan with lower version add 'iac' as includeTags)",
 							"scope": "resource"
 					},
 					"spectral.scan.engines.useOssEngine": {
 						"type": "boolean",
 						"default": false,
-						"description": "Use open source engine kind (Supported from Spectral version 1.10.48 and above)",
+						"description": "Open source engine (Supported from Spectral version 1.10.48 and above)",
 						"scope": "resource"
 				},
 					"spectral.scan.includeTags": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 			"properties": {
 					"spectral.scan.engines.useSecretsEngine": {
 							"type": "boolean",
-							"default": false,
+							"default": true,
 							"description": "Secrets and misconfigurations engine (Supported from Spectral version 1.10.48 and above)",
 							"scope": "resource"
 					},

--- a/package.json
+++ b/package.json
@@ -137,6 +137,34 @@
 					"when": "spectral:hasSpectralInstalled"
 				}
 			]
+		},
+		"configuration": {
+			"type": "object",
+			"title": "Spectral",
+			"properties": {
+					"spectral.scan.engines.useSecretsEngine": {
+							"type": "boolean",
+							"default": false,
+							"description": "Use Secrets and misconfigurations engine kind (Supported with Spectral version higher then 1.10.48)",
+							"scope": "resource"
+					},
+					"spectral.scan.engines.useIacEngine": {
+							"type": "boolean",
+							"default": false,
+							"description": "Use infrastructure as code engine kind (Supported with Spectral version higher then 1.10.48, for IaC scan with lower version add 'iac' as includeTags)",
+							"scope": "resource"
+					},
+					"spectral.scan.includeTags": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							},
+							"maxItems": 100,
+							"default": [],
+							"description": "Scan include tags",
+							"scope": "resource"
+					}
+			}
 		}
 	},
 	"scripts": {

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -1,34 +1,18 @@
-import { ConfigurationChangeEvent, WorkspaceConfiguration } from 'vscode'
-import { ScanEngine } from './constants'
-
-export const CONFIGURATION_IDENTIFIER = 'spectral'
-export const USE_IAC_ENGINE_SETTING = 'scan.engines.useIacEngine'
-export const USE_OSS_ENGINE_SETTING = 'scan.engines.useOssEngine'
-export const USE_SECRET_ENGINE_SETTING = 'scan.engines.useSecretsEngine'
-export const INCLUDE_TAGS_SETTING = 'scan.includeTags'
-
-const prefixIdentifier = (settings: Array<string>) =>
-  settings.map((setting) => `${CONFIGURATION_IDENTIFIER}.${setting}`)
+import { WorkspaceConfiguration } from 'vscode'
+import {
+  CONFIGURATION_IDENTIFIER,
+  INCLUDE_TAGS_SETTING,
+  ScanEngine,
+  USE_IAC_ENGINE_SETTING,
+  USE_OSS_ENGINE_SETTING,
+  USE_SECRET_ENGINE_SETTING,
+} from './constants'
 
 export class Configuration {
   private extensionConfig: WorkspaceConfiguration
   static instance: Configuration
   constructor(workspace) {
     this.extensionConfig = workspace.getConfiguration(CONFIGURATION_IDENTIFIER)
-    workspace.onDidChangeConfiguration(
-      async (event: ConfigurationChangeEvent): Promise<void> => {
-        const changed = prefixIdentifier([
-          USE_SECRET_ENGINE_SETTING,
-          USE_IAC_ENGINE_SETTING,
-          INCLUDE_TAGS_SETTING,
-        ]).find((setting) => event.affectsConfiguration(setting))
-        if (changed) {
-          this.extensionConfig = workspace.getConfiguration(
-            CONFIGURATION_IDENTIFIER
-          )
-        }
-      }
-    )
   }
 
   public static getInstance(workspace?) {
@@ -68,5 +52,10 @@ export class Configuration {
     return this.extensionConfig
       .get<Array<string>>(INCLUDE_TAGS_SETTING, [])
       .join(',')
+  }
+
+  updateConfiguration = (workspace) => {
+    const extensionConfig = workspace.getConfiguration(CONFIGURATION_IDENTIFIER)
+    this.extensionConfig = extensionConfig
   }
 }

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -1,0 +1,64 @@
+import { ConfigurationChangeEvent, WorkspaceConfiguration } from 'vscode'
+import { ScanEngine } from './constants'
+
+export const CONFIGURATION_IDENTIFIER = 'spectral'
+export const USE_IAC_ENGINE_SETTING = 'scan.engines.useIacEngine'
+export const USE_SECRET_ENGINE_SETTING = 'scan.engines.useSecretsEngine'
+export const INCLUDE_TAGS_SETTING = 'scan.includeTags'
+
+const prefixIdentifier = (settings: Array<string>) =>
+  settings.map((setting) => `${CONFIGURATION_IDENTIFIER}.${setting}`)
+
+export class Configuration {
+  private extensionConfig: WorkspaceConfiguration
+  static instance: Configuration
+  constructor(workspace) {
+    this.extensionConfig = workspace.getConfiguration(CONFIGURATION_IDENTIFIER)
+    workspace.onDidChangeConfiguration(
+      async (event: ConfigurationChangeEvent): Promise<void> => {
+        const changed = prefixIdentifier([
+          USE_SECRET_ENGINE_SETTING,
+          USE_IAC_ENGINE_SETTING,
+          INCLUDE_TAGS_SETTING,
+        ]).find((setting) => event.affectsConfiguration(setting))
+        if (changed) {
+          this.extensionConfig = workspace.getConfiguration(
+            CONFIGURATION_IDENTIFIER
+          )
+        }
+      }
+    )
+  }
+
+  public static getInstance(workspace?) {
+    if (!this.instance) {
+      this.instance = new Configuration(workspace)
+    }
+    return this.instance
+  }
+
+  get engines() {
+    const engines = []
+    const useSecretsEngine = this.extensionConfig.get<boolean>(
+      USE_SECRET_ENGINE_SETTING,
+      true
+    )
+    if (useSecretsEngine) {
+      engines.push(ScanEngine.secrets)
+    }
+    const useIacEngine = this.extensionConfig.get<boolean>(
+      USE_IAC_ENGINE_SETTING,
+      true
+    )
+    if (useIacEngine) {
+      engines.push(ScanEngine.iac)
+    }
+    return engines.join(',')
+  }
+
+  get includeTags() {
+    return this.extensionConfig
+      .get<Array<string>>(INCLUDE_TAGS_SETTING, [])
+      .join(',')
+  }
+}

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -54,7 +54,7 @@ export class Configuration {
       .join(',')
   }
 
-  updateConfiguration = (workspace) => {
+  public updateConfiguration = (workspace) => {
     const extensionConfig = workspace.getConfiguration(CONFIGURATION_IDENTIFIER)
     this.extensionConfig = extensionConfig
   }

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -3,6 +3,7 @@ import { ScanEngine } from './constants'
 
 export const CONFIGURATION_IDENTIFIER = 'spectral'
 export const USE_IAC_ENGINE_SETTING = 'scan.engines.useIacEngine'
+export const USE_OSS_ENGINE_SETTING = 'scan.engines.useOssEngine'
 export const USE_SECRET_ENGINE_SETTING = 'scan.engines.useSecretsEngine'
 export const INCLUDE_TAGS_SETTING = 'scan.includeTags'
 
@@ -52,6 +53,13 @@ export class Configuration {
     )
     if (useIacEngine) {
       engines.push(ScanEngine.iac)
+    }
+    const useOssEngine = this.extensionConfig.get<boolean>(
+      USE_OSS_ENGINE_SETTING,
+      true
+    )
+    if (useOssEngine) {
+      engines.push(ScanEngine.oss)
     }
     return engines.join(',')
   }

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -25,22 +25,19 @@ export class Configuration {
   get engines() {
     const engines = []
     const useSecretsEngine = this.extensionConfig.get<boolean>(
-      USE_SECRET_ENGINE_SETTING,
-      true
+      USE_SECRET_ENGINE_SETTING
     )
     if (useSecretsEngine) {
       engines.push(ScanEngine.secrets)
     }
     const useIacEngine = this.extensionConfig.get<boolean>(
-      USE_IAC_ENGINE_SETTING,
-      true
+      USE_IAC_ENGINE_SETTING
     )
     if (useIacEngine) {
       engines.push(ScanEngine.iac)
     }
     const useOssEngine = this.extensionConfig.get<boolean>(
-      USE_OSS_ENGINE_SETTING,
-      true
+      USE_OSS_ENGINE_SETTING
     )
     if (useOssEngine) {
       engines.push(ScanEngine.oss)

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -61,3 +61,9 @@ export const FINDING_POSITION_LINE_INDEX = 0
 export const FINDING_POSITION_COL_INDEX = 1
 export const PLAYBOOKS_URL =
   'https://get.spectralops.io/api/v1/issues/playbooks'
+
+export const CONFIGURATION_IDENTIFIER = 'spectral'
+export const USE_IAC_ENGINE_SETTING = 'scan.engines.useIacEngine'
+export const USE_OSS_ENGINE_SETTING = 'scan.engines.useOssEngine'
+export const USE_SECRET_ENGINE_SETTING = 'scan.engines.useSecretsEngine'
+export const INCLUDE_TAGS_SETTING = 'scan.includeTags'

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -41,6 +41,11 @@ export enum FindingType {
   iac = 'iac',
 }
 
+export enum ScanEngine {
+  secrets = 'secrets',
+  iac = 'iac',
+}
+
 export const severityMapping = {
   [FindingSeverity.error]: FindingSeverity.high,
   [FindingSeverity.warning]: FindingSeverity.medium,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,6 +9,7 @@ export const SCAN_STATE = 'scanState'
 export const PRE_SCAN = 'preScan'
 export const SPECTRAL_VIEW_SECRETS = 'spectral.views.secrets'
 export const SPECTRAL_VIEW_IAC = 'spectral.views.iac'
+export const SPECTRAL_VIEW_OSS = 'spectral.views.oss'
 
 export enum ScanState {
   preScan = 'preScan',
@@ -39,11 +40,13 @@ export enum FindingSeverityLevel {
 export enum FindingType {
   secret = 'secret',
   iac = 'iac',
+  oss = 'oss',
 }
 
 export enum ScanEngine {
   secrets = 'secrets',
   iac = 'iac',
+  oss = 'oss',
 }
 
 export const severityMapping = {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -8,6 +8,7 @@ export type FindingsTypeResults = Record<string, Array<ScanFinding>>
 export type FindingsAggregations = {
   secret: number
   iac: number
+  oss: number
 }
 
 export type ScanResult = {
@@ -23,6 +24,7 @@ export interface ScanFinding {
 
 export interface ScanFindingView extends ScanFinding {
   rootPath: string
+  labelDisplayName: string
 }
 
 type FindingMetadata = {

--- a/src/common/vs-code.ts
+++ b/src/common/vs-code.ts
@@ -192,10 +192,10 @@ export const getWorkspaceFolders = (): Array<string> =>
   workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) || []
 
 export const getFindingRange = (finding: ScanFinding): Range => {
-  const startRow = finding.position.start[FINDING_POSITION_LINE_INDEX]
-  const startCol = finding.position.start[FINDING_POSITION_COL_INDEX]
-  const endRow = finding.position.end[FINDING_POSITION_LINE_INDEX]
-  const endCol = finding.position.end[FINDING_POSITION_COL_INDEX]
+  const startRow = finding.position?.start[FINDING_POSITION_LINE_INDEX] || 0
+  const startCol = finding.position?.start[FINDING_POSITION_COL_INDEX] || 0
+  const endRow = finding.position?.end[FINDING_POSITION_LINE_INDEX] || 0
+  const endCol = finding.position?.end[FINDING_POSITION_COL_INDEX] || 0
   const startLine = startRow > 0 ? startRow - 1 : 1
   const startChar = startCol <= 1 ? startCol : startCol - 1
   const endLine = endRow > 0 ? endRow - 1 : 1

--- a/src/services/spectral-agent-service.ts
+++ b/src/services/spectral-agent-service.ts
@@ -18,6 +18,7 @@ import {
 import { formatWindowsPath, isWindows } from '../common/utils'
 
 import SecretStorageService from './secret-storage-service'
+import { Configuration } from '../common/configuration'
 
 export class SpectralAgentService {
   public findings: Findings
@@ -48,8 +49,6 @@ export class SpectralAgentService {
       const spectralArgs = [
         '--nobanners',
         'scan',
-        '--include-tags',
-        'base,iac',
         '--nosend',
         '--ok',
         '--internal-output',
@@ -57,6 +56,14 @@ export class SpectralAgentService {
       ]
       const options: any = {
         cwd: scanPath,
+      }
+      const engines = Configuration.getInstance().engines
+      if (!isEmpty(engines)) {
+        spectralArgs.push('--engines', engines)
+      }
+      const tags = Configuration.getInstance().includeTags
+      if (!isEmpty(tags)) {
+        spectralArgs.push('--include-tags', tags)
       }
       if (isWindows()) {
         spectralArgs.push('--dsn', dsn)

--- a/src/services/spectral-agent-service.ts
+++ b/src/services/spectral-agent-service.ts
@@ -130,12 +130,20 @@ export class SpectralAgentService {
 
     item.rule.severity = this.mapToNewSeverity(item.rule.severity)
     item.finding = item.finding.toLowerCase()
+    item.labelDisplayName = item.rule.name
+
     this.findingsAggregations[item.rule.severity] += 1
     const isIac = item.metadata.tags.includes(FindingType.iac)
+    const isOss = item.metadata.tags.includes(FindingType.oss)
+
     let findingTypeResults
     if (isIac) {
       findingTypeResults = this.findings[FindingType.iac]
       this.findingsAggregations[FindingType.iac] += 1
+    } else if (isOss) {
+      item.labelDisplayName = `${item.rule.name} - ${item.rule.id}`
+      findingTypeResults = this.findings[FindingType.oss]
+      this.findingsAggregations[FindingType.oss] += 1
     } else {
       findingTypeResults = this.findings[FindingType.secret]
       this.findingsAggregations[FindingType.secret] += 1
@@ -157,10 +165,15 @@ export class SpectralAgentService {
   }
 
   private resetFindings() {
-    this.findings = { [FindingType.iac]: {}, [FindingType.secret]: {} }
+    this.findings = {
+      [FindingType.iac]: {},
+      [FindingType.secret]: {},
+      [FindingType.oss]: {},
+    }
     this.findingsAggregations = {
       [FindingType.secret]: 0,
       [FindingType.iac]: 0,
+      [FindingType.oss]: 0,
     }
   }
 

--- a/src/spectral/extension.ts
+++ b/src/spectral/extension.ts
@@ -5,11 +5,17 @@ import {
   workspace,
   WorkspaceFoldersChangeEvent,
   TextEditor,
+  ConfigurationChangeEvent,
 } from 'vscode'
 import {
+  CONFIGURATION_IDENTIFIER,
+  INCLUDE_TAGS_SETTING,
   SPECTRAL_SCAN,
   SPECTRAL_SET_DSN,
   SPECTRAL_SHOW_OUTPUT,
+  USE_IAC_ENGINE_SETTING,
+  USE_OSS_ENGINE_SETTING,
+  USE_SECRET_ENGINE_SETTING,
 } from '../common/constants'
 import {
   HAS_DSN,
@@ -37,13 +43,14 @@ export class SpectralExtension {
   private workspaceFolders: Array<string> = getWorkspaceFolders()
   private readonly contextService: ContextService
   private readonly logger: LoggerService
+  private readonly configuration: Configuration
   private readonly spectralAgentService: SpectralAgentService
   private readonly resultsView: ResultsView
 
   constructor() {
     this.contextService = ContextService.getInstance()
     this.logger = LoggerService.getInstance()
-    Configuration.getInstance(workspace)
+    this.configuration = Configuration.getInstance(workspace)
     this.spectralAgentService = new SpectralAgentService()
     this.resultsView = new ResultsView()
   }
@@ -126,5 +133,19 @@ export class SpectralExtension {
     window.onDidChangeActiveTextEditor((event: TextEditor | undefined) => {
       updateFindingsDecorations(event, this.spectralAgentService.findings)
     })
+    workspace.onDidChangeConfiguration(
+      async (event: ConfigurationChangeEvent): Promise<void> => {
+        const changed = [
+          `${CONFIGURATION_IDENTIFIER}.${USE_SECRET_ENGINE_SETTING}`,
+          `${CONFIGURATION_IDENTIFIER}.${USE_IAC_ENGINE_SETTING}`,
+          `${CONFIGURATION_IDENTIFIER}.${USE_OSS_ENGINE_SETTING}`,
+          `${CONFIGURATION_IDENTIFIER}.${INCLUDE_TAGS_SETTING}`,
+        ].find((setting) => event.affectsConfiguration(setting))
+        if (changed) {
+          workspace.getConfiguration(CONFIGURATION_IDENTIFIER)
+          this.configuration.updateConfiguration(workspace)
+        }
+      }
+    )
   }
 }

--- a/src/spectral/extension.ts
+++ b/src/spectral/extension.ts
@@ -31,6 +31,7 @@ import { ResultsView } from './results-view'
 import SecretStorageService from '../services/secret-storage-service'
 import { getWorkspaceFolders } from '../common/vs-code'
 import { AnalyticsService } from '../services/analytics-service'
+import { Configuration } from '../common/configuration'
 
 export class SpectralExtension {
   private workspaceFolders: Array<string> = getWorkspaceFolders()
@@ -42,6 +43,7 @@ export class SpectralExtension {
   constructor() {
     this.contextService = ContextService.getInstance()
     this.logger = LoggerService.getInstance()
+    Configuration.getInstance(workspace)
     this.spectralAgentService = new SpectralAgentService()
     this.resultsView = new ResultsView()
   }

--- a/src/spectral/results-items.ts
+++ b/src/spectral/results-items.ts
@@ -10,11 +10,7 @@ import L from 'lodash'
 import { basename, dirname, join } from 'path'
 import isEmpty from 'lodash/isEmpty'
 import { getFindingRange } from '../common/vs-code'
-import {
-  FindingsTypeResults,
-  ScanFinding,
-  ScanFindingView,
-} from '../common/types'
+import { FindingsTypeResults, ScanFindingView } from '../common/types'
 import { FindingSeverity, FindingSeverityLevel } from '../common/constants'
 
 export class FindingsProvider implements TreeDataProvider<TreeItem> {
@@ -91,8 +87,8 @@ export class FindingItem extends TreeItem {
       'informational.svg'
     ),
   }
-  constructor(finding: ScanFinding) {
-    super(finding.rule.name, TreeItemCollapsibleState.None)
+  constructor(finding: ScanFindingView) {
+    super(finding.labelDisplayName, TreeItemCollapsibleState.None)
     const findingPosition = getFindingRange(finding)
     this.tooltip = L.capitalize(finding.rule.severity)
     this.iconPath = {
@@ -110,7 +106,7 @@ export class FindingItem extends TreeItem {
 export class FileItem extends TreeItem {
   findingNodes: Array<FindingItem>
 
-  constructor(filePath: string, findings: Array<ScanFinding>) {
+  constructor(filePath: string, findings: Array<ScanFindingView>) {
     super(basename(filePath), TreeItemCollapsibleState.Collapsed)
     this.resourceUri = Uri.file(filePath)
     this.iconPath = ThemeIcon.File

--- a/src/spectral/results-view.ts
+++ b/src/spectral/results-view.ts
@@ -10,7 +10,11 @@ import {
   FindingsAggregations,
   FindingsTypeResults,
 } from '../common/types'
-import { SPECTRAL_VIEW_IAC, SPECTRAL_VIEW_SECRETS } from '../common/constants'
+import {
+  SPECTRAL_VIEW_IAC,
+  SPECTRAL_VIEW_OSS,
+  SPECTRAL_VIEW_SECRETS,
+} from '../common/constants'
 import { FindingsProvider } from './results-items'
 
 export class ResultsView {
@@ -33,6 +37,12 @@ export class ResultsView {
       results: findings.iac,
       viewId: SPECTRAL_VIEW_IAC,
       viewTitle: `IaC (${findingsAggregations.iac})`,
+    })
+
+    this.createResultsViews({
+      results: findings.oss,
+      viewId: SPECTRAL_VIEW_OSS,
+      viewTitle: `Open Source (${findingsAggregations.oss})`,
     })
 
     if (this.problemsCollection) {

--- a/src/test/mocks/scan-results.mock.ts
+++ b/src/test/mocks/scan-results.mock.ts
@@ -67,7 +67,11 @@ export const scanOssSingleFinding: ScanResult = {
 }
 
 export const scanSingleFindingEachType: ScanResult = {
-  items: concat(scanSecretsSingleFinding.items, scanIacSingleFinding.items),
+  items: concat(
+    scanSecretsSingleFinding.items,
+    scanIacSingleFinding.items,
+    scanOssSingleFinding.items
+  ),
 }
 
 export const scanMultipleSecrets: ScanResult = {

--- a/src/test/mocks/scan-results.mock.ts
+++ b/src/test/mocks/scan-results.mock.ts
@@ -44,6 +44,28 @@ export const scanIacSingleFinding: ScanResult = {
   ],
 }
 
+export const scanOssSingleFinding: ScanResult = {
+  items: [
+    {
+      finding: '/Users/testUser/git/vscode-extension/package-lock.json',
+      position: {
+        start: [1, 1],
+        end: [1, 1],
+      },
+      rule: {
+        id: 'CVE-2018-20834',
+        name: 'CVE-2018-20834',
+        severity: FindingSeverity.high,
+        description:
+          'A vulnerability was found in node-tar before version 4.4.2 (excluding version 2.2.2). An Arbitrary File Overwrite issue exists when extracting a tarball containing a hardlink to a file that already exists on the system, in conjunction with a later plain file with the same name as the hardlink. This plain file content replaces the existing file content. A patch has been applied to node-tar v2.2.2).',
+      },
+      metadata: {
+        tags: ['oss'],
+      },
+    },
+  ],
+}
+
 export const scanSingleFindingEachType: ScanResult = {
   items: concat(scanSecretsSingleFinding.items, scanIacSingleFinding.items),
 }

--- a/src/test/unit/services/spectral-agent-service.test.ts
+++ b/src/test/unit/services/spectral-agent-service.test.ts
@@ -20,19 +20,19 @@ suite('Spectral agent service', () => {
 
   test('[ok] - process only iac - aggregations should be as items length', () => {
     const spectralAgentService = new SpectralAgentService()
-    spectralAgentService.processResults(scanOssSingleFinding, 'somePath')
+    spectralAgentService.processResults(scanIacSingleFinding, 'somePath')
     assert.strictEqual(
-      spectralAgentService.findingsAggregations.oss,
-      scanOssSingleFinding.items.length
+      spectralAgentService.findingsAggregations.iac,
+      scanIacSingleFinding.items.length
     )
   })
 
   test('[ok] - process only oss - aggregations should be as items length', () => {
     const spectralAgentService = new SpectralAgentService()
-    spectralAgentService.processResults(scanIacSingleFinding, 'somePath')
+    spectralAgentService.processResults(scanOssSingleFinding, 'somePath')
     assert.strictEqual(
-      spectralAgentService.findingsAggregations.iac,
-      scanIacSingleFinding.items.length
+      spectralAgentService.findingsAggregations.oss,
+      scanOssSingleFinding.items.length
     )
   })
 

--- a/src/test/unit/services/spectral-agent-service.test.ts
+++ b/src/test/unit/services/spectral-agent-service.test.ts
@@ -40,11 +40,17 @@ suite('Spectral agent service', () => {
     const spectralAgentService = new SpectralAgentService()
     spectralAgentService.processResults(scanSingleFindingEachType, 'somePath')
     const expectedIacItems = 1
+    const expectedOssItems = 1
     const expectedSecretsItems = 1
     assert.strictEqual(
       spectralAgentService.findingsAggregations.iac,
       expectedIacItems,
       'iac validation failed'
+    )
+    assert.strictEqual(
+      spectralAgentService.findingsAggregations.oss,
+      expectedOssItems,
+      'oss validation failed'
     )
     assert.strictEqual(
       spectralAgentService.findingsAggregations.secret,
@@ -63,7 +69,7 @@ suite('Spectral agent service', () => {
   test('[ok] - process finding - different findings should be aggregated by different finding path', () => {
     const spectralAgentService = new SpectralAgentService()
     spectralAgentService.processResults(scanMultipleSecrets, 'somePath')
-    const expectedKeys = scanSingleFindingEachType.items.length
+    const expectedKeys = 2
     const actualKeys = Object.keys(spectralAgentService.findings.secret).length
     assert.strictEqual(actualKeys, expectedKeys)
   })

--- a/src/test/unit/services/spectral-agent-service.test.ts
+++ b/src/test/unit/services/spectral-agent-service.test.ts
@@ -3,6 +3,7 @@ import { SpectralAgentService } from '../../../services/spectral-agent-service'
 import {
   scanIacSingleFinding,
   scanMultipleSecrets,
+  scanOssSingleFinding,
   scanSecretsSingleFinding,
   scanSingleFindingEachType,
 } from '../../mocks/scan-results.mock'
@@ -18,6 +19,15 @@ suite('Spectral agent service', () => {
   })
 
   test('[ok] - process only iac - aggregations should be as items length', () => {
+    const spectralAgentService = new SpectralAgentService()
+    spectralAgentService.processResults(scanOssSingleFinding, 'somePath')
+    assert.strictEqual(
+      spectralAgentService.findingsAggregations.oss,
+      scanOssSingleFinding.items.length
+    )
+  })
+
+  test('[ok] - process only oss - aggregations should be as items length', () => {
     const spectralAgentService = new SpectralAgentService()
     spectralAgentService.processResults(scanIacSingleFinding, 'somePath')
     assert.strictEqual(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,7 +1184,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.5:
+minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==


### PR DESCRIPTION
## Related Issues
https://github.com/SpectralOps/vscode-extension/issues/4

## Description
1. Add extension settings with supporting Spectral "engines" and "IncludeTags"
2. Add OSS engine kind option and view.

## Motivation and Context
- A user requested for this particular feature to be included.
- Users want to choose their preferred tags and engines as spectral ability increases with more engines.

## How Has This Been Tested?
1. Open vs-code settings page -> extensions -> Spectral -> should see the engine and includeTags settings.
![image](https://github.com/SpectralOps/vscode-extension/assets/27979092/49df919f-e19a-446e-b0b7-0836899cda94)
2. Set one/two/all engines and includeTags if needed
3. Run a scan from the extension
4. Oss results should be shown on the new tree menu items called Open Source
![image](https://github.com/SpectralOps/vscode-extension/assets/27979092/32551347-4b2a-4ed8-adbf-d6fab247a872)

# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting