### PR TITLE
reset findings before scanning all workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove the usage of --ok flag
 - Reset issues before scanning workspace folders
+- fix action button bug
 
 ## [1.0.14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.0.18]
 
 - Remove the usage of --ok flag
+- Reset issues before scanning workspace folders
 
 ## [1.0.14]
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 			{
 				"command": "spectral.scan",
 				"title": "Spectral scan",
-				"icon": "$(refresh)"
+				"icon": "$(refresh)",
+				"category": "Spectral"
 			},
 			{
 				"command": "spectral.showOutput",
@@ -51,7 +52,8 @@
 			{
 				"command": "spectral.setDsn",
 				"title": "Spectral Set DSN",
-				"icon": "$(settings-gear)"
+				"icon": "$(settings-gear)",
+				"category": "Spectral"
 			}
 		],
 		"viewsContainers": {
@@ -118,12 +120,12 @@
 			"view/title": [
 				{
 					"command": "spectral.scan",
-					"when": "!spectral:preScan || spectral:scanState == 'failed' && spectral:hasSpectralInstalled && spectral:hasDsn || spectral:hasLicense",
+					"when": "view == spectral.views.secrets || view == spectral.views.scanState",
 					"group": "navigation"
 				},
 				{
 					"command": "spectral.setDsn",
-					"when": "spectral:hasSpectralInstalled && spectral:hasDsn || spectral:hasLicense",
+					"when": "view == spectral.views.secrets || view == spectral.views.welcome || view == spectral.views.scanState && spectral:hasSpectralInstalled || spectral:hasLicense",
 					"group": "navigation"
 				}
 			],

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,10 +5,7 @@ export type Findings = Record<FindingType, FindingsTypeResults>
 
 export type FindingsTypeResults = Record<string, Array<ScanFinding>>
 
-export type FindingsAggregations = {
-  secret: number
-  iac: number
-}
+export type FindingsAggregations = Record<FindingType, number>
 
 export type ScanResult = {
   items: Array<ScanFinding>

--- a/src/services/spectral-agent-service.ts
+++ b/src/services/spectral-agent-service.ts
@@ -101,10 +101,17 @@ export class SpectralAgentService {
   }
 
   public processResults(results: ScanResult, folderPath: string) {
-    this.resetFindings()
     results?.items?.forEach((item: ScanFindingView) => {
       this.processFindingItem({ item, folderPath: folderPath.toLowerCase() })
     })
+  }
+
+  public resetFindings() {
+    this.findings = { [FindingType.iac]: {}, [FindingType.secret]: {} }
+    this.findingsAggregations = {
+      [FindingType.secret]: 0,
+      [FindingType.iac]: 0,
+    }
   }
 
   private processFindingItem({
@@ -147,14 +154,6 @@ export class SpectralAgentService {
     }
 
     return `${SPECTRAL_FOLDER}/spectral`
-  }
-
-  private resetFindings() {
-    this.findings = { [FindingType.iac]: {}, [FindingType.secret]: {} }
-    this.findingsAggregations = {
-      [FindingType.secret]: 0,
-      [FindingType.iac]: 0,
-    }
   }
 
   private mapToNewSeverity(itemSeverity: FindingSeverity): FindingSeverity {

--- a/src/services/spectral-agent-service.ts
+++ b/src/services/spectral-agent-service.ts
@@ -102,11 +102,17 @@ export class SpectralAgentService {
   }
 
   public resetFindings() {
-    this.findings = { [FindingType.iac]: {}, [FindingType.secret]: {} }
-    this.findingsAggregations = {
-      [FindingType.secret]: 0,
-      [FindingType.iac]: 0,
-    }
+    this.findings = Object.values(FindingType).reduce((acc, key) => {
+      acc[key] = {}
+      return acc
+    }, {} as Findings)
+    this.findingsAggregations = Object.values(FindingType).reduce(
+      (acc, key) => {
+        acc[key] = 0
+        return acc
+      },
+      {} as FindingsAggregations
+    )
   }
 
   private processFindingItem({

--- a/src/spectral/commands.ts
+++ b/src/spectral/commands.ts
@@ -50,6 +50,7 @@ export const scanWorkSpaceFolders = async ({
   AnalyticsService.track('vscode-scan')
   inProgressStatusBarItem.show()
   try {
+    spectralAgentService.resetFindings()
     await runWithLoaderOnView({
       viewId: SPECTRAL_VIEW_SECRETS,
       action: () =>

--- a/src/spectral/extension.ts
+++ b/src/spectral/extension.ts
@@ -62,7 +62,7 @@ export class SpectralExtension {
     vsCodeContext: ExtensionContext
   ): Promise<void> {
     SecretStorageService.init(vsCodeContext)
-    this.contextService.setContext(PRE_SCAN, true)
+    await this.contextService.setContext(PRE_SCAN, true)
     this.registerCommands(vsCodeContext)
     this.registerEvents()
   }


### PR DESCRIPTION
## Description
Reset previous scan issues before starting a new scan.

## Motivation and Context
This change was required because the issues from the previous scan were deleted from the view before processing the new scan, resulting in a bug when scanning for multiple folders in one workspace.
For example, I added two folders to the same workspace and started a scan:
- the first folder was scanned -> issues were saved
- reset scan issues -> delete the issues from the first folder
- the second folder was scanned -> display only issues from the second folder

## How Has This Been Tested?
- scanned one folder -> display issues from the folder
- add a folder to the workspace -> display issues from both of the folders
- removed a folder from the workspace -> display issues only from the folder in the workspace

# Checklist
- [x] Tests
- [ ] Documentation
- [ ] Linting